### PR TITLE
Specifying object name in pos and quat get/set

### DIFF
--- a/include/robot_interfaces/finger.hpp
+++ b/include/robot_interfaces/finger.hpp
@@ -316,10 +316,10 @@ public:
     // \todo: implement forward kinematics
     virtual Vector get_tip_pos() const = 0;
 
-    virtual Vector get_object_pos() const = 0;
-    virtual void set_object_pos(const Vector &pos) = 0;
+    virtual Vector get_object_pos(std::string object_name) const = 0;
+    virtual void set_object_pos(const Vector &pos, std::string object_name) = 0;
 
-    virtual Quaternion get_object_quat() const = 0;
+    virtual Quaternion get_object_quat(std::string object_name) const = 0;
 
     virtual Vector get_target_pos() const = 0;
     virtual void set_target_pos(const Vector &pos) const = 0;


### PR DESCRIPTION
A simple change which adds `object_name` string parameter to object properties get and set methods. This is needed for Level 4 object manipulation where multiple different object are considered.